### PR TITLE
Add coverage folder and .ruby-gemset to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+/coverage
+
+# Ignore gemset config.
+.ruby-gemset


### PR DESCRIPTION
Coverage folder is generated by CircleCI and by RSpec. We don't need to
commit these to our repo. The .ruby-gemset file is necessary on my own
machine.
