### PR TITLE
Dcr8898 fix css

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
       </div>
     </div>
   </div>
+  <div class='container'>
     <%= yield %>
   </div>
 </body>

--- a/vendor/assets/stylesheets/skeleton.css
+++ b/vendor/assets/stylesheets/skeleton.css
@@ -121,7 +121,7 @@ are based on 10px sizing. So basically 1.5rem = 15px :) */
 html {
   font-size: 62.5%; }
 body {
-  background-color: #AAC4D1;
+  background-color: #f0f0f0;
   opacity: 0.9;
   font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
   line-height: 1.6;
@@ -129,7 +129,7 @@ body {
   font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #222; }
 header {
-  background-color: #f0f0f0 }
+  background-color: #f0f0f0; }
 .form-button {
   display: inline; }
 


### PR DESCRIPTION
This fixes a bug in the application layout file that removed the <div class='container> tag that previously wrapped the yield block.
This also changes the overall background color to light grey, which looks better with the link colors (for the moment).
