### PR TITLE
Stevenxl questions destroy

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -91,7 +91,7 @@ class QuestionsController < ApplicationController
 
     unless question.user == current_user
       flash[:notice] = "Action failed. You are not the owner of this question."
-      redirect_to question
+      redirect_to question_path(question)
     end
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,8 +1,4 @@
 class QuestionsController < ApplicationController
-  before_action :logged_in_user, except: [:index, :show, :unanswered]
-
-  before_action :verify_ownership, only: [:update, :destroy]
-
   def index
     @questions = Question.most_voted
   end
@@ -77,21 +73,5 @@ class QuestionsController < ApplicationController
 
   def question_params
     params.require(:question).permit(:title, :body)
-  end
-
-  def logged_in_user
-    unless logged_in?
-      flash[:notice] = "Please log in."
-      redirect_to login_path
-    end
-  end
-
-  def verify_ownership
-    question = Question.find_by(id: params[:id])
-
-    unless question.user == current_user
-      flash[:notice] = "Action failed. You are not the owner of this question."
-      redirect_to question_path(question)
-    end
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -62,10 +62,17 @@ class QuestionsController < ApplicationController
     end
   end
 
+  def destroy
+    question = Question.find_by(id: params[:id])
+
+    question.destroy
+    flash[:notice] = "You've successfully deleted #{question.title}"
+    redirect_to root_path
+  end
+
   private
 
   def question_params
     params.require(:question).permit(:title, :body)
   end
-
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,7 @@
 class QuestionsController < ApplicationController
+  before_action :logged_in_user, except: [:index, :show, :unanswered]
+
+  before_action :verify_ownership, only: [:update, :destroy]
 
   def index
     @questions = Question.most_voted
@@ -74,5 +77,21 @@ class QuestionsController < ApplicationController
 
   def question_params
     params.require(:question).permit(:title, :body)
+  end
+
+  def logged_in_user
+    unless logged_in?
+      flash[:notice] = "Please log in."
+      redirect_to login_path
+    end
+  end
+
+  def verify_ownership
+    question = Question.find_by(id: params[:id])
+
+    unless question.user == current_user
+      flash[:notice] = "Action failed. You are not the owner of this question."
+      redirect_to question
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,9 +35,7 @@
     <% if flash.any?  %>
       <div id="flash">
         <% flash.each do |type, message| %>
-          <div class="<%= type %> ">
-            <%= message %>
-          </div>
+          <%= content_tag :div, message, class: type %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,8 @@
 <div id="question-header">
 	<h4><%= @question.title %></h4>
+  <% if current_user == @question.user %>
+    <%= link_to "Delete Question", @question, method: :delete, class: "button" %>
+  <% end %>
 </div>
 
 <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get    'questions/unanswered', to: 'questions#unanswered'
 
-  resources :questions, only: [:index, :create, :new, :show, :destroy] do
+  resources :questions do
     resources :answers, only: [:create] do
       resources :comments, only: [:create]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,13 @@ Rails.application.routes.draw do
 
   get    'questions/unanswered', to: 'questions#unanswered'
 
+  resources :questions, only: [:index, :create, :new, :show, :destroy] do
+    resources :answers, only: [:create] do
+      resources :comments, only: [:create]
+    end
+    resources :comments, only: [:create]
+  end
+
   get    'login',  to: 'sessions#new'
   post   'login',  to: 'sessions#create'
   get    'logout', to: 'sessions#destroy'

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -5,6 +5,11 @@ describe QuestionsController do
   let(:user) { FactoryGirl.create(:user) }
   let(:valid_attrs) { FactoryGirl.build(:question).attributes }
   let(:invalid_attrs) { FactoryGirl.build(:question, body: nil).attributes }
+  let!(:question) { FactoryGirl.create(:question, user_id: user.id) }
+
+  before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
 
 
   context "#index" do
@@ -37,9 +42,6 @@ describe QuestionsController do
   end
 
   context '#create' do
-    before(:each) do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-    end
 
     it 'creates a question from valid parameters' do
       expect {
@@ -78,7 +80,7 @@ describe QuestionsController do
   end
 
   context '#update' do
-    let!(:question) { FactoryGirl.create(:question) }
+
     it 'updates question with valid parameters' do
       expect {
         patch :update, id: question.id, question: { body: 'test' }
@@ -129,11 +131,9 @@ describe QuestionsController do
   end
 
   context "#destroy" do
-    let(:question) { FactoryGirl.create(:question) }
-
 
     context "user is owner of question" do
-      subject { delete :destroy, {id: question.id}, {user_id: question.user.id} }
+      subject { delete :destroy, {id: question.id} }
 
       it "should redirect to root path" do
         subject.should redirect_to root_path
@@ -147,24 +147,6 @@ describe QuestionsController do
       it "deletes the question" do
         question #create question in database
         expect{subject}.to change{ Question.count }.by(-1)
-      end
-    end
-
-    context "user is not owner of the question" do
-      subject { delete :destroy, {id: question.id}, {user_id: nil} }
-
-      it "should redirect back to the question" do
-        subject.should redirect_to question_path(question)
-      end
-
-      it "should set a flash notice" do
-        subject
-        expect(flash[:error]).to eq("Delete failed. You are not the owner of this question.")
-      end
-
-      it "should not change the number of questions" do
-        question #create question in database
-        expect{subject}.not_to change{Question.count}
       end
     end
   end


### PR DESCRIPTION
Note: In the `destroy` action of the Questions controller, in the case in which a user cannot delete a question, they will be redirected back to that question. This breaks with our other routes in which we **render** a specific view. I did this because the show view depends on a lot of items, and re-creating that view here would lead to a lot of duplication. 

(I can always change this action to be consistent with our other actions if there is agreement / a good reason to do so).
