### PR TITLE
Dcr8898 sessions flash message

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       redirect_to user
     else
-      @errors = ["Invalid username/password combination."]
+      flash.now.alert = "Invalid username/password combination."
       render 'new'
     end
   end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<h4>Login</h4>
 <%= form_for(:session, url: login_path) do |f| %>
   <div>
     <%= f.label :username %>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -42,14 +42,9 @@ describe SessionsController do
         subject.should render_template("new")
       end
 
-      it "assigns @errors" do
+      it "assigns flash message" do
         subject
-        expect(assigns(:errors)).to be_a Array
-      end
-
-      it "should not divulge too much information" do
-        subject
-        expect(assigns(:errors).length).to eq(1)
+        expect(flash.now[:alert]).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
This just updates Sessions#create action to use flash message for errors, instead of error block (consistent with the our practice elsewhere in the app).
